### PR TITLE
Update to _MSC_VER "fix" for MSVC 2017 and later

### DIFF
--- a/lib/udunits2.h
+++ b/lib/udunits2.h
@@ -11,7 +11,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER<1910
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>


### PR DESCRIPTION
The fix in udunits2.h needed for older versions of _MSC_VER breaks with newer versions; modified to only apply fix when _MSC_VER is less than 1910 (MSVC 2017), as that is when the corrected code was added to the Windows SDK.

Tested with _MSC_VER == 1920 (Visual Studio 2019).